### PR TITLE
fix: 修正依頼 #7 への対応（WORKS 見出しと一覧の間隔）

### DIFF
--- a/app/(home)/components/Works.tsx
+++ b/app/(home)/components/Works.tsx
@@ -15,7 +15,7 @@ export default async function Works() {
       <div className="max-w-6xl mx-auto px-6">
         <SectionTitle color="accent">WORKS</SectionTitle>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 -mt-8">
           {worksList.contents.map((work) => (
             <WorksCard
               key={work.id}


### PR DESCRIPTION
修正依頼 #7 に対する、AI が自動生成した変更提案です。

- 依頼の内容と作業ルールは #7 を参照してください
- 変更は見た目に閉じた範囲に限定されています
- **マージは人が判断します。** この仕組みに本番へ出す権限はありません

## AI の判断

見出し `WORKS` を描画している `SectionTitle` は他ページ（SERVICE / SKILL / PRICE）でも共通利用されているため、**そちらは変更せず**、WORKS セクション側のグリッドに `-mt-8` を追加して間隔だけを詰めています。

Closes #7