### PR TITLE
fix: 変更提案の作成手順が失敗を隠していた問題を修正

### DIFF
--- a/.github/workflows/fix-request.yml
+++ b/.github/workflows/fix-request.yml
@@ -97,14 +97,21 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
+          # -e は付けない。失敗を握りつぶさず、内容を見て判断するため。
+          set -uo pipefail
 
-          if ! gh api "repos/$REPO/branches/$BRANCH" >/dev/null 2>&1; then
-            echo "ブランチ $BRANCH がありません。変更が加えられなかったとみなして終了します。"
-            exit 0
+          echo "対象ブランチ: $BRANCH"
+
+          # 事前の存在確認はしない。確認が失敗しただけで「変更なし」と
+          # 誤判定し、静かに何もしない事故が実際に起きたため。
+          # 作成を試み、その結果で判断する。
+
+          EXISTING="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+            --json number --jq '.[0].number // empty' 2>&1)"
+          if [ $? -ne 0 ]; then
+            echo "既存の変更提案を確認できませんでした（続行します）: $EXISTING"
+            EXISTING=""
           fi
-
-          EXISTING="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
           if [ -n "$EXISTING" ]; then
             echo "すでに変更提案 #$EXISTING があります。"
             exit 0
@@ -119,7 +126,21 @@ jobs:
             "" \
             "Closes #${ISSUE_NUMBER}")
 
-          gh pr create --repo "$REPO" --base develop --head "$BRANCH" \
-            --title "fix: 修正依頼 #${ISSUE_NUMBER} への対応" \
-            --body "$BODY" \
-            || echo "変更提案を作れませんでした（develop との差が無い可能性があります）。"
+          if OUT="$(gh pr create --repo "$REPO" --base develop --head "$BRANCH" \
+            --title "fix: 修正依頼 #${ISSUE_NUMBER} への対応" --body "$BODY" 2>&1)"; then
+            echo "変更提案を作成しました: $OUT"
+            exit 0
+          fi
+
+          echo "変更提案を作成できませんでした。理由:"
+          echo "$OUT"
+          case "$OUT" in
+            *"No commits between"*|*"no commits between"*)
+              echo "→ develop との差がないためです。異常ではありません。"
+              exit 0
+              ;;
+            *)
+              echo "→ 想定外の失敗です。仕組みの不具合として扱います。"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## 何が起きたか

2回目の実地検証（#7）で、ワークフローの「変更提案を作る」手順は **success と表示されたのに、変更提案は作られていませんでした**。

ログを読むと、事前のブランチ存在確認が失敗し、「変更が加えられなかった」と誤判定して静かに終了していました。しかし該当ブランチは実在します。

問題は2つ重なっていました。

1. **エラー出力を `/dev/null` に捨てていた** → 失敗の理由が分からない
2. **`|| echo` で握りつぶしていた** → 手順は「成功」と表示される

E2E で「スクリプトが読み込めていないのに合格と判定していた」のと同じ、**偽の合格**です。

## 直すこと

- **事前の存在確認を廃止**。確認の失敗を「変更なし」と誤判定する経路そのものを無くし、作成を試みて**結果で判断**します
- **エラー出力を捨てない**。失敗理由をログに残します
- **差が無いだけなら正常終了、それ以外の失敗は手順を失敗させます**。静かに成功と表示されるより、赤く失敗するほうが安全です

🤖 Generated with [Claude Code](https://claude.com/claude-code)