### PR TITLE
見た目の自動チェックを develop に配置し、誤った「問題なし」報告を直す

### DIFF
--- a/.github/scripts/.gitignore
+++ b/.github/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/scripts/lib/compare.mjs
+++ b/.github/scripts/lib/compare.mjs
@@ -1,0 +1,41 @@
+/**
+ * 2枚のスクリーンショットを比べる。
+ *
+ * 高さが違う場合は重なる範囲だけで比べ、高さの変化そのものも結果に含める
+ * （内容が増減した合図になるため）。
+ */
+
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+
+export function compare(beforeBuffer, afterBuffer) {
+  const before = PNG.sync.read(beforeBuffer);
+  const after = PNG.sync.read(afterBuffer);
+
+  const width = Math.min(before.width, after.width);
+  const height = Math.min(before.height, after.height);
+  const heightChanged = before.height !== after.height;
+
+  const crop = (png) => {
+    if (png.width === width && png.height === height) return png;
+    const out = new PNG({ width, height });
+    PNG.bitblt(png, out, 0, 0, width, height, 0, 0);
+    return out;
+  };
+
+  const a = crop(before);
+  const b = crop(after);
+  const diff = new PNG({ width, height });
+  const changed = pixelmatch(a.data, b.data, diff.data, width, height, {
+    threshold: 0.1,
+  });
+
+  return {
+    changedPixels: changed,
+    percent: (changed / (width * height)) * 100,
+    heightChanged,
+    beforeHeight: before.height,
+    afterHeight: after.height,
+    diffImage: PNG.sync.write(diff),
+  };
+}

--- a/.github/scripts/lib/report.mjs
+++ b/.github/scripts/lib/report.mjs
@@ -1,0 +1,123 @@
+/**
+ * 検査結果を、依頼者（コードを読まない人）が読める文章に組み立てる。
+ *
+ * この文章がそのまま依頼の Issue に書き込まれ、「取り込んでよいか」の判断材料になる。
+ *
+ * 🔴 最重要の決まり: **検査できなかったことを「問題なし」と書かない。**
+ *    比較元が取れない・合言葉が違う・時間切れといった理由で判定が出せないとき、
+ *    まとめだけ読んだ人が承認してしまうと、安全網があるつもりで壊れたものが本番へ出る。
+ */
+
+/** これを超える差分は「依頼以外も動いた可能性」として警告する */
+export const DIFF_WARN_PERCENT = 5;
+
+export function buildSummary(results, preview, targetPath, checks = {}) {
+  const isTarget = (r) => targetPath !== undefined && r.target.path === targetPath;
+
+  const lines = [
+    "## 自動チェックの結果",
+    "",
+    `**確認用 URL: ${preview}**`,
+    "（開くには合言葉が必要です。担当者にお尋ねください）",
+    "",
+    "比較元は `develop` のプレビューです。",
+    "",
+    ...machineChecks(checks),
+    "### 見た目の比べ方",
+    "",
+    "| 見た場所 | 依頼の対象 | 変化 | 画面のエラー |",
+    "|---|---|---|---|",
+  ];
+
+  for (const r of results) {
+    const scope = isTarget(r) ? "◯ 依頼した場所" : "—";
+    if (r.error) {
+      lines.push(`| ${r.target.label} | ${scope} | ⚠️ 確認できず | ${r.error} |`);
+      continue;
+    }
+    const pct = r.diff.percent;
+    const height = r.diff.heightChanged
+      ? `・高さ ${r.diff.beforeHeight}→${r.diff.afterHeight}px`
+      : "";
+    const mark = pct > 0 ? `${pct.toFixed(2)}%${height}` : "変化なし";
+    const errors = r.consoleErrors.length === 0 ? "なし" : `⚠️ ${r.consoleErrors.length}件`;
+    lines.push(`| ${r.target.label} | ${scope} | ${mark} | ${errors} |`);
+  }
+
+  lines.push("");
+
+  const measured = results.filter((r) => !r.error);
+  const failedCount = results.length - measured.length;
+
+  if (measured.length === 0) {
+    // 1か所も判定できていない。ここで安心させる文を出すと安全網が逆に働く
+    lines.push(
+      "⚠️ **どの場所も確認できませんでした。** 自動チェックは判定を出せていません。" +
+        "取り込む前に、必ず人の目で確認用 URL をご覧ください。",
+    );
+  } else {
+    const unexpected = measured.filter(
+      (r) => !isTarget(r) && r.diff.percent >= DIFF_WARN_PERCENT,
+    );
+    const untouched = measured.filter((r) => !isTarget(r) && r.diff.percent === 0);
+
+    if (unexpected.length > 0) {
+      lines.push(
+        `⚠️ **依頼していない場所が ${unexpected.length} か所変化しています。** ` +
+          `依頼の範囲を超えた変更が入っていないか、取り込む前にご確認ください。`,
+      );
+    } else if (untouched.length > 0) {
+      lines.push(
+        `依頼した場所以外の ${untouched.length} か所は**まったく変化していません**。` +
+          `依頼の範囲に収まっていると判断できます。`,
+      );
+    } else {
+      lines.push("依頼の範囲を超える変化は見つかりませんでした。");
+    }
+
+    if (failedCount > 0) {
+      lines.push(
+        "",
+        `⚠️ ただし ${failedCount} か所は確認できませんでした。` +
+          "上の表の「確認できず」の行をご覧ください。その場所については判定できていません。",
+      );
+    }
+  }
+
+  const allErrors = results.flatMap((r) => r.consoleErrors ?? []);
+  if (allErrors.length > 0) {
+    lines.push("", "### 画面で発生したエラー", "", "```", ...allErrors.slice(0, 5), "```");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * ジョブを失敗させるべきかを決める。
+ * 見た目の変化は依頼どおりでも大きく出るため、報告にとどめて止めない。
+ * 止めるのは「画面のエラー」と「検査そのものができなかった場合」だけ。
+ */
+export function shouldFail(results) {
+  return results.some((r) => r.error || (r.consoleErrors?.length ?? 0) > 0);
+}
+
+/** ビルドと文法チェックの結果を、コードを読まない人向けの言葉で表にする */
+function machineChecks(checks) {
+  const rows = [
+    ["ビルド（サイトが組み上がるか）", checks.build],
+    ["文法チェック（書き方の誤り）", checks.lint],
+  ].filter(([, state]) => state !== undefined);
+
+  if (rows.length === 0) return [];
+
+  const label = (state) =>
+    state === "ok" ? "✅ 通った" : state === "failed" ? "❌ 通らなかった" : "⚠️ 確認できず";
+
+  return [
+    "### 機械のチェック",
+    "",
+    "| 項目 | 結果 |",
+    "|---|---|",
+    ...rows.map(([name, state]) => `| ${name} | ${label(state)} |`),
+    "",
+  ];
+}

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "portfolio-visual-check",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "portfolio-visual-check",
+      "dependencies": {
+        "pixelmatch": "^6.0.0",
+        "playwright": "^1.50.0",
+        "pngjs": "^7.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
+      "integrity": "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -7,5 +7,8 @@
     "pixelmatch": "^6.0.0",
     "playwright": "^1.50.0",
     "pngjs": "^7.0.0"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
   }
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "portfolio-visual-check",
+  "private": true,
+  "type": "module",
+  "description": "見た目の自動チェック。サイト本体のビルドとは独立させ、依存を混ぜない",
+  "dependencies": {
+    "pixelmatch": "^6.0.0",
+    "playwright": "^1.50.0",
+    "pngjs": "^7.0.0"
+  }
+}

--- a/.github/scripts/test/compare.test.mjs
+++ b/.github/scripts/test/compare.test.mjs
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { PNG } from "pngjs";
+
+import { compare } from "../lib/compare.mjs";
+
+/** 単色の PNG を作る。fill は [r,g,b] */
+function solid(width, height, [r, g, b]) {
+  const png = new PNG({ width, height });
+  for (let i = 0; i < width * height; i++) {
+    png.data[i * 4] = r;
+    png.data[i * 4 + 1] = g;
+    png.data[i * 4 + 2] = b;
+    png.data[i * 4 + 3] = 255;
+  }
+  return PNG.sync.write(png);
+}
+
+/** 上半分だけ色を変えた PNG を作る */
+function halfPainted(width, height, base, painted) {
+  const png = PNG.sync.read(solid(width, height, base));
+  for (let y = 0; y < height / 2; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      png.data[i] = painted[0];
+      png.data[i + 1] = painted[1];
+      png.data[i + 2] = painted[2];
+    }
+  }
+  return PNG.sync.write(png);
+}
+
+test("同じ画像なら変化なしと判定する", () => {
+  const a = solid(20, 10, [255, 255, 255]);
+  const result = compare(a, solid(20, 10, [255, 255, 255]));
+  assert.equal(result.changedPixels, 0);
+  assert.equal(result.percent, 0);
+  assert.equal(result.heightChanged, false);
+});
+
+test("一部が変わったら、その割合を出す", () => {
+  const before = solid(20, 10, [255, 255, 255]);
+  const after = halfPainted(20, 10, [255, 255, 255], [0, 0, 0]);
+  const result = compare(before, after);
+  assert.equal(result.changedPixels, 100); // 20x10 の上半分 = 100px
+  assert.equal(result.percent, 50);
+});
+
+test("高さが変わったことを検知し、重なる範囲だけで比べる", () => {
+  const before = solid(20, 10, [255, 255, 255]);
+  const after = solid(20, 30, [255, 255, 255]);
+  const result = compare(before, after);
+  assert.equal(result.heightChanged, true);
+  assert.equal(result.beforeHeight, 10);
+  assert.equal(result.afterHeight, 30);
+  // 重なる 20x10 の範囲は同じなので、差分そのものは 0
+  assert.equal(result.changedPixels, 0);
+});
+
+test("差分画像が PNG として書き出せる", () => {
+  const result = compare(solid(8, 8, [255, 255, 255]), halfPainted(8, 8, [255, 255, 255], [255, 0, 0]));
+  const decoded = PNG.sync.read(result.diffImage);
+  assert.equal(decoded.width, 8);
+  assert.equal(decoded.height, 8);
+});

--- a/.github/scripts/test/report.test.mjs
+++ b/.github/scripts/test/report.test.mjs
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSummary } from "../lib/report.mjs";
+
+const PREVIEW = "https://example.vercel.app";
+
+/** 検査できたページ1件分 */
+const ok = (path, label, percent, { consoleErrors = [] } = {}) => ({
+  target: { path, label, width: 1280, height: 800 },
+  diff: {
+    percent,
+    heightChanged: false,
+    beforeHeight: 800,
+    afterHeight: 800,
+    changedPixels: Math.round(percent * 100),
+  },
+  consoleErrors,
+});
+
+/** 検査できなかったページ1件分 */
+const ng = (path, label, error) => ({
+  target: { path, label, width: 1280, height: 800 },
+  error,
+});
+
+test("表には見た場所すべての行が出る", () => {
+  const md = buildSummary(
+    [ok("/", "トップ", 0), ok("/works", "実績一覧", 0)],
+    PREVIEW,
+    "/",
+  );
+  assert.match(md, /\| トップ \|/);
+  assert.match(md, /\| 実績一覧 \|/);
+});
+
+test("依頼していない場所が大きく変化したら警告する", () => {
+  const md = buildSummary(
+    [ok("/", "トップ", 1.2), ok("/works", "実績一覧", 40)],
+    PREVIEW,
+    "/",
+  );
+  assert.match(md, /依頼していない場所が 1 か所変化しています/);
+});
+
+test("依頼した場所の変化は警告の対象にしない", () => {
+  const md = buildSummary([ok("/", "トップ", 40), ok("/works", "実績一覧", 0)], PREVIEW, "/");
+  assert.doesNotMatch(md, /依頼していない場所が/);
+  assert.match(md, /まったく変化していません/);
+});
+
+test("依頼以外がすべて無変化なら、範囲に収まっていると伝える", () => {
+  const md = buildSummary([ok("/", "トップ", 3), ok("/works", "実績一覧", 0)], PREVIEW, "/");
+  assert.match(md, /1 か所は\*\*まったく変化していません\*\*/);
+});
+
+// ▼ ここから下は、現状の実装では通らないはず（＝直すべき欠陥）
+
+test("どの場所も確認できなかったときに『問題なし』と言ってはいけない", () => {
+  const md = buildSummary(
+    [
+      ng("/", "トップ", "プレビューが 401 を返しました"),
+      ng("/works", "実績一覧", "プレビューが 401 を返しました"),
+    ],
+    PREVIEW,
+    "/",
+  );
+  assert.doesNotMatch(md, /見つかりませんでした/);
+  assert.doesNotMatch(md, /収まっていると判断できます/);
+  assert.match(md, /どの場所も確認できませんでした/);
+  assert.match(md, /人の目/);
+});
+
+test("一部が確認できなかったら、その事実をまとめにも書く", () => {
+  const md = buildSummary(
+    [ok("/", "トップ", 3), ok("/works", "実績一覧", 0), ng("/about", "私たちについて", "時間切れ")],
+    PREVIEW,
+    "/",
+  );
+  assert.match(md, /1 か所は確認できませんでした/);
+});
+
+test("比較元が取れなかったことが、原因として分かる文言になっている", () => {
+  const md = buildSummary(
+    [ng("/", "トップ", "比較元（develop）が 404 を返しました。差分は判定できません")],
+    PREVIEW,
+    "/",
+  );
+  assert.match(md, /比較元/);
+  assert.doesNotMatch(md, /見つかりませんでした/);
+});
+
+test("ビルドと文法チェックの結果が、同じコメントの中に出る", () => {
+  const md = buildSummary([ok("/", "トップ", 0)], PREVIEW, "/", {
+    build: "ok",
+    lint: "failed",
+  });
+  assert.match(md, /### 機械のチェック/);
+  assert.match(md, /ビルド（サイトが組み上がるか） \| ✅ 通った/);
+  assert.match(md, /文法チェック（書き方の誤り） \| ❌ 通らなかった/);
+});
+
+test("機械チェックの結果を渡さなければ、その表は出さない", () => {
+  const md = buildSummary([ok("/", "トップ", 0)], PREVIEW, "/");
+  assert.doesNotMatch(md, /### 機械のチェック/);
+});
+
+test("機械チェックが確認できなかった場合は、通ったとは書かない", () => {
+  const md = buildSummary([ok("/", "トップ", 0)], PREVIEW, "/", { build: "unknown" });
+  assert.match(md, /⚠️ 確認できず/);
+  assert.doesNotMatch(md, /ビルド（サイトが組み上がるか） \| ✅/);
+});

--- a/.github/scripts/visual-check.mjs
+++ b/.github/scripts/visual-check.mjs
@@ -12,7 +12,8 @@
  *
  * 使い方:
  *   node visual-check.mjs --preview <URL> --baseline <URL> \
- *     [--target-path </works>] [--out <dir>]
+ *     [--target-path </works>] [--out <dir>] \
+ *     [--build-status ok|failed|unknown] [--lint-status ok|failed|unknown]
  * 環境変数:
  *   BASIC_AUTH_USER / BASIC_AUTH_PASSWORD … プレビューの合言葉（比較元にも必要）
  */
@@ -20,9 +21,10 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import pixelmatch from "pixelmatch";
-import { PNG } from "pngjs";
 import { chromium } from "playwright";
+
+import { compare } from "./lib/compare.mjs";
+import { buildSummary, shouldFail } from "./lib/report.mjs";
 
 /** 見る場所。ここを増やすと検査は厚くなるが時間も伸びる */
 const TARGETS = [
@@ -32,9 +34,6 @@ const TARGETS = [
   { path: "/about", width: 1280, height: 800, label: "私たちについて" },
   { path: "/service", width: 1280, height: 800, label: "サービス" },
 ];
-
-/** これを超える差分は「依頼以外も動いた可能性」として警告する */
-const DIFF_WARN_PERCENT = 5;
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -53,6 +52,12 @@ function parseArgs() {
     // 依頼が指していたページ。ここの変化は想定内、他ページの変化は要確認
     targetPath: get("target-path"),
     out: get("out") ?? "visual-check-out",
+    // ビルドと文法チェックの結果。依頼者が1つのコメントだけ読めば済むよう、
+    // 見た目の判定と同じ文章に混ぜて出す
+    checks: {
+      build: get("build-status"),
+      lint: get("lint-status"),
+    },
   };
 }
 
@@ -75,44 +80,8 @@ async function capture(context, url, target) {
   return { buffer, consoleErrors, status };
 }
 
-/**
- * 2枚を比べる。高さが違う場合は重なる範囲だけで比べ、
- * 高さの変化そのものも結果に含める（内容が増減した合図になるため）。
- */
-function compare(beforeBuffer, afterBuffer) {
-  const before = PNG.sync.read(beforeBuffer);
-  const after = PNG.sync.read(afterBuffer);
-
-  const width = Math.min(before.width, after.width);
-  const height = Math.min(before.height, after.height);
-  const heightChanged = before.height !== after.height;
-
-  const crop = (png) => {
-    if (png.width === width && png.height === height) return png;
-    const out = new PNG({ width, height });
-    PNG.bitblt(png, out, 0, 0, width, height, 0, 0);
-    return out;
-  };
-
-  const a = crop(before);
-  const b = crop(after);
-  const diff = new PNG({ width, height });
-  const changed = pixelmatch(a.data, b.data, diff.data, width, height, {
-    threshold: 0.1,
-  });
-
-  return {
-    changedPixels: changed,
-    percent: (changed / (width * height)) * 100,
-    heightChanged,
-    beforeHeight: before.height,
-    afterHeight: after.height,
-    diffImage: PNG.sync.write(diff),
-  };
-}
-
 async function main() {
-  const { preview, baseline, targetPath, out } = parseArgs();
+  const { preview, baseline, targetPath, out, checks } = parseArgs();
   await mkdir(out, { recursive: true });
 
   const user = process.env.BASIC_AUTH_USER;
@@ -136,6 +105,16 @@ async function main() {
         results.push({ target, error: `プレビューが ${after.status} を返しました` });
         continue;
       }
+      // 🔴 比較元も必ず確認する。ここを見ないと、比較元が 401 や 404 のときに
+      //    エラーページ同士・エラーページと正常ページを比べ、
+      //    「変化なし」や「余計な場所が変わった」という誤った判定を出してしまう。
+      if (before.status !== 200) {
+        results.push({
+          target,
+          error: `比較元（develop）が ${before.status} を返しました。差分は判定できません`,
+        });
+        continue;
+      }
 
       const diff = compare(before.buffer, after.buffer);
       await writeFile(path.join(out, `${name}-after.png`), after.buffer);
@@ -149,76 +128,11 @@ async function main() {
 
   await browser.close();
 
-  const summary = buildSummary(results, preview, targetPath);
+  const summary = buildSummary(results, preview, targetPath, checks);
   await writeFile(path.join(out, "summary.md"), summary, "utf-8");
   console.log(summary);
 
-  // 失敗とみなすのは「画面のエラー」と「検査そのものの失敗」だけ。
-  // 見た目の変化は依頼どおりでも大きく出るため、報告にとどめて止めない。
-  const hasProblem = results.some(
-    (r) => r.error || (r.consoleErrors?.length ?? 0) > 0,
-  );
-  process.exit(hasProblem ? 1 : 0);
-}
-
-function buildSummary(results, preview, targetPath) {
-  const isTarget = (r) => targetPath !== undefined && r.target.path === targetPath;
-
-  const lines = [
-    "## 自動チェックの結果",
-    "",
-    `**確認用 URL: ${preview}**`,
-    "（開くには合言葉が必要です。担当者にお尋ねください）",
-    "",
-    "比較元は `develop` のプレビューです。",
-    "",
-    "| 見た場所 | 依頼の対象 | 変化 | 画面のエラー |",
-    "|---|---|---|---|",
-  ];
-
-  for (const r of results) {
-    const scope = isTarget(r) ? "◯ 依頼した場所" : "—";
-    if (r.error) {
-      lines.push(`| ${r.target.label} | ${scope} | ⚠️ 確認できず | ${r.error} |`);
-      continue;
-    }
-    const pct = r.diff.percent;
-    const changed = pct > 0;
-    const height = r.diff.heightChanged
-      ? `・高さ ${r.diff.beforeHeight}→${r.diff.afterHeight}px`
-      : "";
-    const mark = changed ? `${pct.toFixed(2)}%${height}` : "変化なし";
-    const errors = r.consoleErrors.length === 0 ? "なし" : `⚠️ ${r.consoleErrors.length}件`;
-    lines.push(`| ${r.target.label} | ${scope} | ${mark} | ${errors} |`);
-  }
-
-  lines.push("");
-
-  const measured = results.filter((r) => !r.error);
-  const unexpected = measured.filter(
-    (r) => !isTarget(r) && r.diff.percent >= DIFF_WARN_PERCENT,
-  );
-  const untouched = measured.filter((r) => !isTarget(r) && r.diff.percent === 0);
-
-  if (unexpected.length > 0) {
-    lines.push(
-      `⚠️ **依頼していない場所が ${unexpected.length} か所変化しています。** ` +
-        `依頼の範囲を超えた変更が入っていないか、取り込む前にご確認ください。`,
-    );
-  } else if (untouched.length > 0) {
-    lines.push(
-      `依頼した場所以外の ${untouched.length} か所は**まったく変化していません**。` +
-        `依頼の範囲に収まっていると判断できます。`,
-    );
-  } else {
-    lines.push("依頼の範囲を超える変化は見つかりませんでした。");
-  }
-
-  const allErrors = results.flatMap((r) => r.consoleErrors ?? []);
-  if (allErrors.length > 0) {
-    lines.push("", "### 画面で発生したエラー", "", "```", ...allErrors.slice(0, 5), "```");
-  }
-  return lines.join("\n");
+  process.exit(shouldFail(results) ? 1 : 0);
 }
 
 main().catch((error) => {

--- a/.github/scripts/visual-check.mjs
+++ b/.github/scripts/visual-check.mjs
@@ -1,0 +1,227 @@
+/**
+ * 見た目の自動チェック。
+ *
+ * 「依頼された箇所以外が動いていないか」を機械で判定するための道具。
+ * 見た目に閉じた修正に限定している以上、これが最大の安全網になる。
+ *
+ * 検査対象はローカルでビルドしたものではなく、Vercel が作ったプレビュー。
+ * ビルド済みの実物を見るため確実で、外部サービスの資格情報も要らない。
+ *
+ * 比較元は本番ではなく develop のプレビューを使う。
+ * 本番は develop より進んでいることがあり、依頼と無関係な差が混ざるため。
+ *
+ * 使い方:
+ *   node visual-check.mjs --preview <URL> --baseline <URL> \
+ *     [--target-path </works>] [--out <dir>]
+ * 環境変数:
+ *   BASIC_AUTH_USER / BASIC_AUTH_PASSWORD … プレビューの合言葉（比較元にも必要）
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+import { chromium } from "playwright";
+
+/** 見る場所。ここを増やすと検査は厚くなるが時間も伸びる */
+const TARGETS = [
+  { path: "/", width: 1280, height: 800, label: "トップ（パソコン）" },
+  { path: "/", width: 390, height: 844, label: "トップ（スマートフォン）" },
+  { path: "/works", width: 1280, height: 800, label: "実績一覧" },
+  { path: "/about", width: 1280, height: 800, label: "私たちについて" },
+  { path: "/service", width: 1280, height: 800, label: "サービス" },
+];
+
+/** これを超える差分は「依頼以外も動いた可能性」として警告する */
+const DIFF_WARN_PERCENT = 5;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const get = (name) => {
+    const i = args.indexOf(`--${name}`);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const preview = get("preview");
+  const baseline = get("baseline");
+  if (!preview || !baseline) {
+    throw new Error("--preview と --baseline は必須です");
+  }
+  return {
+    preview,
+    baseline,
+    // 依頼が指していたページ。ここの変化は想定内、他ページの変化は要確認
+    targetPath: get("target-path"),
+    out: get("out") ?? "visual-check-out",
+  };
+}
+
+/** 1ページ分を撮る。コンソールのエラーも拾う */
+async function capture(context, url, target) {
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text().slice(0, 200));
+  });
+  page.on("pageerror", (error) => consoleErrors.push(String(error).slice(0, 200)));
+
+  await page.setViewportSize({ width: target.width, height: target.height });
+  const response = await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+  // 遅れて動く装飾が写り込むのを避ける
+  await page.waitForTimeout(1200);
+  const buffer = await page.screenshot({ fullPage: true });
+  const status = response?.status() ?? 0;
+  await page.close();
+  return { buffer, consoleErrors, status };
+}
+
+/**
+ * 2枚を比べる。高さが違う場合は重なる範囲だけで比べ、
+ * 高さの変化そのものも結果に含める（内容が増減した合図になるため）。
+ */
+function compare(beforeBuffer, afterBuffer) {
+  const before = PNG.sync.read(beforeBuffer);
+  const after = PNG.sync.read(afterBuffer);
+
+  const width = Math.min(before.width, after.width);
+  const height = Math.min(before.height, after.height);
+  const heightChanged = before.height !== after.height;
+
+  const crop = (png) => {
+    if (png.width === width && png.height === height) return png;
+    const out = new PNG({ width, height });
+    PNG.bitblt(png, out, 0, 0, width, height, 0, 0);
+    return out;
+  };
+
+  const a = crop(before);
+  const b = crop(after);
+  const diff = new PNG({ width, height });
+  const changed = pixelmatch(a.data, b.data, diff.data, width, height, {
+    threshold: 0.1,
+  });
+
+  return {
+    changedPixels: changed,
+    percent: (changed / (width * height)) * 100,
+    heightChanged,
+    beforeHeight: before.height,
+    afterHeight: after.height,
+    diffImage: PNG.sync.write(diff),
+  };
+}
+
+async function main() {
+  const { preview, baseline, targetPath, out } = parseArgs();
+  await mkdir(out, { recursive: true });
+
+  const user = process.env.BASIC_AUTH_USER;
+  const password = process.env.BASIC_AUTH_PASSWORD;
+
+  const browser = await chromium.launch();
+  // 比較元も develop のプレビューなので、どちらにも合言葉が要る
+  const credentials =
+    user && password ? { httpCredentials: { username: user, password } } : {};
+  const previewContext = await browser.newContext(credentials);
+  const baselineContext = await browser.newContext(credentials);
+
+  const results = [];
+  for (const target of TARGETS) {
+    const name = `${target.path.replace(/\//g, "_") || "_top"}-${target.width}`;
+    try {
+      const after = await capture(previewContext, preview + target.path, target);
+      const before = await capture(baselineContext, baseline + target.path, target);
+
+      if (after.status !== 200) {
+        results.push({ target, error: `プレビューが ${after.status} を返しました` });
+        continue;
+      }
+
+      const diff = compare(before.buffer, after.buffer);
+      await writeFile(path.join(out, `${name}-after.png`), after.buffer);
+      await writeFile(path.join(out, `${name}-diff.png`), diff.diffImage);
+
+      results.push({ target, diff, consoleErrors: after.consoleErrors });
+    } catch (error) {
+      results.push({ target, error: String(error).slice(0, 300) });
+    }
+  }
+
+  await browser.close();
+
+  const summary = buildSummary(results, preview, targetPath);
+  await writeFile(path.join(out, "summary.md"), summary, "utf-8");
+  console.log(summary);
+
+  // 失敗とみなすのは「画面のエラー」と「検査そのものの失敗」だけ。
+  // 見た目の変化は依頼どおりでも大きく出るため、報告にとどめて止めない。
+  const hasProblem = results.some(
+    (r) => r.error || (r.consoleErrors?.length ?? 0) > 0,
+  );
+  process.exit(hasProblem ? 1 : 0);
+}
+
+function buildSummary(results, preview, targetPath) {
+  const isTarget = (r) => targetPath !== undefined && r.target.path === targetPath;
+
+  const lines = [
+    "## 自動チェックの結果",
+    "",
+    `**確認用 URL: ${preview}**`,
+    "（開くには合言葉が必要です。担当者にお尋ねください）",
+    "",
+    "比較元は `develop` のプレビューです。",
+    "",
+    "| 見た場所 | 依頼の対象 | 変化 | 画面のエラー |",
+    "|---|---|---|---|",
+  ];
+
+  for (const r of results) {
+    const scope = isTarget(r) ? "◯ 依頼した場所" : "—";
+    if (r.error) {
+      lines.push(`| ${r.target.label} | ${scope} | ⚠️ 確認できず | ${r.error} |`);
+      continue;
+    }
+    const pct = r.diff.percent;
+    const changed = pct > 0;
+    const height = r.diff.heightChanged
+      ? `・高さ ${r.diff.beforeHeight}→${r.diff.afterHeight}px`
+      : "";
+    const mark = changed ? `${pct.toFixed(2)}%${height}` : "変化なし";
+    const errors = r.consoleErrors.length === 0 ? "なし" : `⚠️ ${r.consoleErrors.length}件`;
+    lines.push(`| ${r.target.label} | ${scope} | ${mark} | ${errors} |`);
+  }
+
+  lines.push("");
+
+  const measured = results.filter((r) => !r.error);
+  const unexpected = measured.filter(
+    (r) => !isTarget(r) && r.diff.percent >= DIFF_WARN_PERCENT,
+  );
+  const untouched = measured.filter((r) => !isTarget(r) && r.diff.percent === 0);
+
+  if (unexpected.length > 0) {
+    lines.push(
+      `⚠️ **依頼していない場所が ${unexpected.length} か所変化しています。** ` +
+        `依頼の範囲を超えた変更が入っていないか、取り込む前にご確認ください。`,
+    );
+  } else if (untouched.length > 0) {
+    lines.push(
+      `依頼した場所以外の ${untouched.length} か所は**まったく変化していません**。` +
+        `依頼の範囲に収まっていると判断できます。`,
+    );
+  } else {
+    lines.push("依頼の範囲を超える変化は見つかりませんでした。");
+  }
+
+  const allErrors = results.flatMap((r) => r.consoleErrors ?? []);
+  if (allErrors.length > 0) {
+    lines.push("", "### 画面で発生したエラー", "", "```", ...allErrors.slice(0, 5), "```");
+  }
+  return lines.join("\n");
+}
+
+main().catch((error) => {
+  console.error("検査そのものが失敗しました:", error);
+  process.exit(2);
+});

--- a/.github/workflows/visual-check.yml
+++ b/.github/workflows/visual-check.yml
@@ -1,7 +1,12 @@
 # 見た目の自動チェック
 #
 # AI が作った修正ブランチに反映があったとき、Vercel が作るプレビューを
-# develop のプレビューと見比べ、結果を依頼の Issue に書き込む。
+# develop のプレビューと見比べ、結果を依頼の Issue に1つのコメントとして書き込む。
+#
+# 🔴 このファイルは develop に置かれていないと動かない。
+#    起点が push であるため、GitHub は「押されたブランチにあるワークフロー」を読む。
+#    AI の修正ブランチは develop から切られる（fix-request.yml の base_branch）ので、
+#    develop に無ければ fix/** をいくら押しても起動しない。
 #
 # 🔴 起点は push である（pull_request ではない）。
 #    変更提案は自動生成しない方針のため、pull_request 起点では動かない。
@@ -35,39 +40,7 @@ jobs:
         with:
           node-version: 24
 
-      - name: 検査に使う道具を用意する
-        working-directory: .github/scripts
-        run: |
-          npm ci || npm install
-          npx playwright install --with-deps chromium
-
-      - name: Vercel のプレビューができるまで待つ
-        id: preview
-        env:
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-          BRANCH: ${{ github.ref_name }}
-          GH_TOKEN: ${{ github.token }}
-          # Vercel のプレビュー URL は「プロジェクト名-git-ブランチ名-スコープ」で決まる
-          VERCEL_SCOPE: moritorajis-projects
-          VERCEL_PROJECT: portfolio
-        run: |
-          set -uo pipefail
-          for i in $(seq 1 40); do
-            STATE="$(gh api "repos/$REPO/commits/$SHA/status" --jq '.state' 2>/dev/null)"
-            echo "  Vercel の状態: ${STATE:-確認中}"
-            [ "$STATE" = "success" ] && break
-            [ "$STATE" = "failure" ] && { echo "Vercel のビルドが失敗しました"; exit 1; }
-            sleep 15
-          done
-          if [ "${STATE:-}" != "success" ]; then
-            echo "待ち時間内にプレビューが用意できませんでした"; exit 1
-          fi
-
-          SLUG="$(printf %s "$BRANCH" | tr '/._' '---')"
-          echo "preview=https://${VERCEL_PROJECT}-git-${SLUG}-${VERCEL_SCOPE}.vercel.app" >> "$GITHUB_OUTPUT"
-          echo "baseline=https://${VERCEL_PROJECT}-git-develop-${VERCEL_SCOPE}.vercel.app" >> "$GITHUB_OUTPUT"
-
+      # 依頼の番号は最初に取る。ビルドが失敗した場合でも依頼者に伝えるため
       - name: 依頼の情報を取り出す
         id: request
         env:
@@ -90,6 +63,87 @@ jobs:
           echo "対象ページ: ${TARGET:-（取得できず）}"
           echo "target=$TARGET" >> "$GITHUB_OUTPUT"
 
+      - name: 検査に使う道具を用意する
+        working-directory: .github/scripts
+        run: |
+          npm ci || npm install
+          npx playwright install --with-deps chromium
+
+      # 安全網そのものが壊れていないかを先に確かめる。
+      # 判定を出す道具が壊れたまま「問題なし」と報告するのが最悪の失敗なので、ここは止める。
+      - name: 検査の道具を自己テストする
+        working-directory: .github/scripts
+        run: npm test
+
+      - name: 文法チェック
+        id: lint
+        continue-on-error: true
+        run: |
+          npm ci
+          npm run lint
+
+      - name: Vercel のプレビューができるまで待つ
+        id: preview
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          # Vercel のプレビュー URL は「プロジェクト名-git-ブランチ名-スコープ」で決まる
+          VERCEL_SCOPE: moritorajis-projects
+          VERCEL_PROJECT: portfolio
+        run: |
+          set -uo pipefail
+          STATE=""
+          for i in $(seq 1 40); do
+            STATE="$(gh api "repos/$REPO/commits/$SHA/status" --jq '.state' 2>/dev/null)"
+            echo "  Vercel の状態: ${STATE:-確認中}"
+            [ "$STATE" = "success" ] && break
+            [ "$STATE" = "failure" ] && break
+            sleep 15
+          done
+
+          case "$STATE" in
+            success) echo "state=success" >> "$GITHUB_OUTPUT" ;;
+            failure) echo "state=failure" >> "$GITHUB_OUTPUT" ;;
+            *)       echo "state=timeout" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+          SLUG="$(printf %s "$BRANCH" | tr '/._' '---')"
+          echo "preview=https://${VERCEL_PROJECT}-git-${SLUG}-${VERCEL_SCOPE}.vercel.app" >> "$GITHUB_OUTPUT"
+          echo "baseline=https://${VERCEL_PROJECT}-git-develop-${VERCEL_SCOPE}.vercel.app" >> "$GITHUB_OUTPUT"
+
+      # ビルドが通らないと見た目は比べられない。黙って終わらず、依頼者に理由を伝える
+      - name: ビルドが通らなかったことを依頼に伝える
+        if: steps.preview.outputs.state != 'success'
+        env:
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ steps.request.outputs.number }}
+          STATE: ${{ steps.preview.outputs.state }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          if [ "$STATE" = "failure" ]; then
+            REASON="サイトの組み立て（ビルド）が通りませんでした。"
+          else
+            REASON="待ち時間の中でプレビューが用意できませんでした。"
+          fi
+          if [ -n "${NUMBER:-}" ]; then
+            {
+              printf '%s\n' "## 自動チェックの結果"
+              printf '%s\n' ""
+              printf '%s\n' "❌ **$REASON**"
+              printf '%s\n' ""
+              printf '%s\n' "確認用 URL は作られていないため、見た目の比較もできていません。"
+              printf '%s\n' "この修正はこのままでは取り込めません。担当者にご連絡ください。"
+              printf '%s\n' ""
+              printf '%s\n' "[実行の記録]($RUN_URL)"
+            } > build-failed.md
+            gh issue comment "$NUMBER" --repo "$REPO" --body-file build-failed.md
+          fi
+          exit 1
+
       - name: 見た目を比べる
         id: check
         continue-on-error: true
@@ -100,6 +154,8 @@ jobs:
           node .github/scripts/visual-check.mjs \
             --preview "${{ steps.preview.outputs.preview }}" \
             --baseline "${{ steps.preview.outputs.baseline }}" \
+            --build-status ok \
+            --lint-status ${{ steps.lint.outcome == 'success' && 'ok' || 'failed' }} \
             ${{ steps.request.outputs.target && format('--target-path "{0}"', steps.request.outputs.target) || '' }} \
             --out visual-check-out
 
@@ -121,20 +177,22 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -uo pipefail
-          mkdir -p visual-check-out
           if [ ! -f visual-check-out/summary.md ]; then
             {
               printf '%s\n' "## 自動チェックの結果"
               printf '%s\n' ""
-              printf '%s\n' "⚠️ 検査を実行できませんでした。[実行記録]($RUN_URL) をご確認ください。"
-            } > visual-check-out-fallback.md
-            gh issue comment "$NUMBER" --repo "$REPO" --body-file visual-check-out-fallback.md
+              printf '%s\n' "⚠️ **検査を実行できませんでした。** 判定は出ていません。"
+              printf '%s\n' "取り込む前に、必ず人の目でご確認ください。"
+              printf '%s\n' ""
+              printf '%s\n' "[実行の記録]($RUN_URL)"
+            } > visual-check-fallback.md
+            gh issue comment "$NUMBER" --repo "$REPO" --body-file visual-check-fallback.md
             exit 0
           fi
           gh issue comment "$NUMBER" --repo "$REPO" --body-file visual-check-out/summary.md
 
-      - name: 画面のエラーがあった場合はジョブを失敗させる
-        if: steps.check.outcome == 'failure'
+      - name: 問題が見つかった場合はジョブを失敗させる
+        if: steps.check.outcome == 'failure' || steps.lint.outcome == 'failure'
         run: |
-          echo "検査で問題が見つかりました。上の書き込みを確認してください。"
+          echo "検査で問題が見つかりました。依頼への書き込みを確認してください。"
           exit 1

--- a/.github/workflows/visual-check.yml
+++ b/.github/workflows/visual-check.yml
@@ -1,0 +1,140 @@
+# 見た目の自動チェック
+#
+# AI が作った修正ブランチに反映があったとき、Vercel が作るプレビューを
+# develop のプレビューと見比べ、結果を依頼の Issue に書き込む。
+#
+# 🔴 起点は push である（pull_request ではない）。
+#    変更提案は自動生成しない方針のため、pull_request 起点では動かない。
+#
+# 前提: リポジトリの Secrets に BASIC_AUTH_USER / BASIC_AUTH_PASSWORD があること
+#       （プレビューはアプリ側の Basic 認証で守られているため）
+
+name: visual-check
+
+on:
+  push:
+    branches: ["fix/**"]
+
+concurrency:
+  group: visual-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+
+      - name: 検査に使う道具を用意する
+        working-directory: .github/scripts
+        run: |
+          npm ci || npm install
+          npx playwright install --with-deps chromium
+
+      - name: Vercel のプレビューができるまで待つ
+        id: preview
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          # Vercel のプレビュー URL は「プロジェクト名-git-ブランチ名-スコープ」で決まる
+          VERCEL_SCOPE: moritorajis-projects
+          VERCEL_PROJECT: portfolio
+        run: |
+          set -uo pipefail
+          for i in $(seq 1 40); do
+            STATE="$(gh api "repos/$REPO/commits/$SHA/status" --jq '.state' 2>/dev/null)"
+            echo "  Vercel の状態: ${STATE:-確認中}"
+            [ "$STATE" = "success" ] && break
+            [ "$STATE" = "failure" ] && { echo "Vercel のビルドが失敗しました"; exit 1; }
+            sleep 15
+          done
+          if [ "${STATE:-}" != "success" ]; then
+            echo "待ち時間内にプレビューが用意できませんでした"; exit 1
+          fi
+
+          SLUG="$(printf %s "$BRANCH" | tr '/._' '---')"
+          echo "preview=https://${VERCEL_PROJECT}-git-${SLUG}-${VERCEL_SCOPE}.vercel.app" >> "$GITHUB_OUTPUT"
+          echo "baseline=https://${VERCEL_PROJECT}-git-develop-${VERCEL_SCOPE}.vercel.app" >> "$GITHUB_OUTPUT"
+
+      - name: 依頼の情報を取り出す
+        id: request
+        env:
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # ブランチ名 fix/issue-<番号>-<日時> から依頼の番号を取る
+          NUMBER="$(printf %s "$BRANCH" | sed -n 's|^fix/issue-\([0-9]\{1,\}\)-.*|\1|p')"
+          if [ -z "$NUMBER" ]; then
+            echo "ブランチ名から依頼の番号を取れませんでした: $BRANCH"
+            exit 0
+          fi
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+          # 依頼の本文から、対象ページのパスを取る（表の「ページ」行）
+          BODY="$(gh issue view "$NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null)"
+          TARGET="$(printf %s "$BODY" | sed -n 's/^| ページ | `\(.*\)` |$/\1/p' | head -1)"
+          echo "対象ページ: ${TARGET:-（取得できず）}"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: 見た目を比べる
+        id: check
+        continue-on-error: true
+        env:
+          BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER }}
+          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+        run: |
+          node .github/scripts/visual-check.mjs \
+            --preview "${{ steps.preview.outputs.preview }}" \
+            --baseline "${{ steps.preview.outputs.baseline }}" \
+            ${{ steps.request.outputs.target && format('--target-path "{0}"', steps.request.outputs.target) || '' }} \
+            --out visual-check-out
+
+      - name: 差分の画像を残す
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: visual-check
+          path: visual-check-out
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: 結果を依頼に書き込む
+        if: always() && steps.request.outputs.number != ''
+        env:
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ steps.request.outputs.number }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          mkdir -p visual-check-out
+          if [ ! -f visual-check-out/summary.md ]; then
+            {
+              printf '%s\n' "## 自動チェックの結果"
+              printf '%s\n' ""
+              printf '%s\n' "⚠️ 検査を実行できませんでした。[実行記録]($RUN_URL) をご確認ください。"
+            } > visual-check-out-fallback.md
+            gh issue comment "$NUMBER" --repo "$REPO" --body-file visual-check-out-fallback.md
+            exit 0
+          fi
+          gh issue comment "$NUMBER" --repo "$REPO" --body-file visual-check-out/summary.md
+
+      - name: 画面のエラーがあった場合はジョブを失敗させる
+        if: steps.check.outcome == 'failure'
+        run: |
+          echo "検査で問題が見つかりました。上の書き込みを確認してください。"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3140](http://localhost:3140) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3140",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"


### PR DESCRIPTION
## なぜ

見た目の自動チェック（S4）は書かれていたが、**一度も動いたことがなかった**。

`visual-check.yml` は push を起点にしている。GitHub は push のとき「押されたブランチにあるワークフロー」を読むため、AI の修正ブランチの基点である `develop` にファイルが無いと永久に起動しない。

配置を直すにあたり中身を検査したところ、依頼者に誤った安心を与える欠陥が見つかったため併せて修正した。

## 直したこと

| 問題 | 直し方 |
|---|---|
| 1か所も判定できていなくても、まとめは「変化は見つかりませんでした」だった | 「どの場所も確認できませんでした。必ず人の目でご確認ください」に。一部失敗も件数を明記 |
| 比較元（develop）の応答を確認していなかった | 200 以外は理由を示して判定しない |
| ビルドが通らないと依頼者に何も届かなかった | 失敗とその意味を Issue に書き込む |
| 文法チェックが無かった | 追加し、ビルド結果と同じ1つのコメントに掲載 |
| 検査の道具自体が無検査だった | 単体テスト14件を新設し、実行前に自己テスト |

## 確認したこと

- 単体テスト **14件すべて合格**（修正前は 4合格 / 3失敗。欠陥をテストで先に証明してから修正）
- 実物のプレビュー比較（`fix/issue-17` と `develop`）: 依頼した場所のみ変化（高さ 2960→2928px）、依頼外の3ページは完全に無変化
- 比較元が 404 の場合: 全行「確認できず」＋人の目での確認を促す。修正前はここで「問題なし」と出ていた
- eslint: 終了コード 0

## 残り

GitHub Actions 上での通し（Issue → 修正 → push → 検査 → コメント）は、このマージ後に1回実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)